### PR TITLE
Publish config example did not work on case-sensitive filesystem.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ php artisan migrate
 To publish config file run this in terminal:
 
 ```bash
-php artisan vendor:publish --provider="DmcBrn\LaravelEmailDatabaseLog\LaravelEmailDatabaseLogServiceProvider"
+php artisan vendor:publish --provider="Dmcbrn\LaravelEmailDatabaseLog\LaravelEmailDatabaseLogServiceProvider"
 ```
 
 Config contains three parameters:


### PR DESCRIPTION
The example command for publishing the assets (config) did not work on Linux.

It seems to be due to case sensitivity and `DmcBrn` vs `Dmcbrn`.


P.S.: Could not find a way to open a regular issue on this fork. 
