### PR TITLE
Laravel 8 + add possibility to use multiple middlewares from env

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Config contains three parameters:
 ```php
 //name of the folder where the attachments will be saved
 'folder' => env('EMAIL_LOG_ATTACHMENT_FOLDER','email_log_attachments'),
-//to prevent access to list of logged emails add a middleware
+//to prevent access to list of logged emails add a middlewares. Multiple middlewares can be used (separate by comma)
 'access_middleware' => env('EMAIL_LOG_ACCESS_MIDDLEWARE',null),
 //this parameter prefixes the routes for listing of logged emails
 'routes_prefix' => env('EMAIL_LOG_ROUTES_PREFIX',''),
@@ -87,7 +87,7 @@ You can review sent emails using the following URI `/email-log`.
 
 You can prefix this URI by adding something like `EMAIL_LOG_ROUTES_PREFIX=prefix/` to your .env file.
 
-You can protect this URI using middleware by adding something like `EMAIL_LOG_ACCESS_MIDDLEWARE=auth` to your .env file.
+You can protect this URI using middleware by adding something like `EMAIL_LOG_ACCESS_MIDDLEWARE=auth,landlord` to your .env file.
 
 ## MailGun webhooks
 

--- a/composer.json
+++ b/composer.json
@@ -10,10 +10,10 @@
         }
     ],
     "require": {
-        "illuminate/support": "~7.0",
-        "illuminate/database": "~7.0",
-        "illuminate/mail": "~7.0",
-        "illuminate/queue": "~7.0",
+        "illuminate/support": "~7.0|~8.0",
+        "illuminate/database": "~7.0|~8.0",
+        "illuminate/mail": "~7.0|~8.0",
+        "illuminate/queue": "~7.0|~8.0",
         "doctrine/dbal": "*"
     },
     "autoload": {

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,8 +1,10 @@
 <?php
+$accessMiddlewares = config('email_log.access_middleware', null) 
+    ? explode(',' , config('email_log.access_middleware')) : [];
 
 Route::group([
     'prefix' => config('email_log.routes_prefix', ''),
-    'middleware' => array_filter(['web',config('email_log.access_middleware', null)]),
+    'middleware' => array_merge(['web'], $accessMiddlewares),
 ], function(){
     Route::get('/email-log', ['as' => 'email-log', 'uses' => 'Dmcbrn\LaravelEmailDatabaseLog\EmailLogController@index']);
     Route::post('/email-log/delete', ['as' => 'email-log.delete-old', 'uses' => 'Dmcbrn\LaravelEmailDatabaseLog\EmailLogController@deleteOldEmails']);

--- a/src/LaravelEmailDatabaseLogServiceProvider.php
+++ b/src/LaravelEmailDatabaseLogServiceProvider.php
@@ -17,13 +17,13 @@ class LaravelEmailDatabaseLogServiceProvider extends EventServiceProvider
             EmailLogger::class,
         ],
     ];
-    
+
     public function register()
     {
 //        $this->app->make('Dmcbrn\LaravelEmailDatabaseLog\EmailLogController');
-        
-        $this->loadViewsFrom(__DIR__.'/../views','email-logger');
-        
+
+        $this->loadViewsFrom(__DIR__ . '/../views','email-logger');
+
         $this->mergeConfigFrom(
             __DIR__ . '/../config/email_log.php', 'email_log'
         );

--- a/src/LaravelEmailDatabaseLogServiceProvider.php
+++ b/src/LaravelEmailDatabaseLogServiceProvider.php
@@ -2,25 +2,17 @@
 
 namespace Dmcbrn\LaravelEmailDatabaseLog;
 
-use Illuminate\Foundation\Support\Providers\EventServiceProvider;
+use Illuminate\Support\ServiceProvider;
 use Illuminate\Mail\Events\MessageSending;
 
-class LaravelEmailDatabaseLogServiceProvider extends EventServiceProvider
+class LaravelEmailDatabaseLogServiceProvider extends ServiceProvider
 {
-    /**
-     * The event listener mappings for the application.
-     *
-     * @var array
-     */
-    protected $listen = [
-        MessageSending::class => [
-            EmailLogger::class,
-        ],
-    ];
 
     public function register()
     {
 //        $this->app->make('Dmcbrn\LaravelEmailDatabaseLog\EmailLogController');
+
+        $this->app['events']->listen(MessageSending::class, EmailLogger::class);
 
         $this->loadViewsFrom(__DIR__ . '/../views','email-logger');
 
@@ -36,8 +28,6 @@ class LaravelEmailDatabaseLogServiceProvider extends EventServiceProvider
      */
     public function boot()
     {
-        parent::boot();
-
         $this->loadRoutesFrom(__DIR__.'/../routes/web.php');
         $this->loadMigrationsFrom(__DIR__ . '/../database/migrations');
         $this->publishes([


### PR DESCRIPTION
Also changes the way listener is registered in service provider. Old way, the listener was shown as registered but listener did not actually work when mail was sent (email was not saved to db). If it worked before, then there is probably some changes in framework.