### PR TITLE
Configurable toggle for filtering unknown emails when handling MailGun events.

### DIFF
--- a/config/email_log.php
+++ b/config/email_log.php
@@ -4,4 +4,8 @@ return [
     'folder' => env('EMAIL_LOG_ATTACHMENT_FOLDER','email_log_attachments'),
     'access_middleware' => env('EMAIL_LOG_ACCESS_MIDDLEWARE',null),
     'routes_prefix' => env('EMAIL_LOG_ROUTES_PREFIX',''), //when changing prefix please be sure to update the webhook's URLs also
+    'mailgun' => [
+        'secret' => env('MAILGUN_SECRET', null),
+        'filter_unknown_emails' => env('EMAIL_LOG_MAILGUN_FILTER_UNKNOWN_EMAILS', true),
+    ],
 ];


### PR DESCRIPTION
Adds toggle whether MailGun events for (currently) unknown emails should be discarded or not.

This is useful when introducing this package in a system that is already using MailGun with a bit of volume. 

With the aggressive attempts at MailGun for getting mails out, you could see up to a few weeks of events being retried as emails are retried again and again by the system.

It is also useful if you often purge / clean out the log table and MailGun still has events related to those mails now deleted from the log table. Similarly when you jump between testing servers and move the MailGun webhooks, the avalanche of unknowns gets cumbersome.

P.S.: The `env('MAILGUN_SECRET', null),` was also changed into a config due to recommendations regarding Laravel configuration caching. (TL;DR: Never use `env` outside of `config\` folder.)

