### PR TITLE
Added support from Laravel 9 and 10, with switch to caret version range

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,10 +10,10 @@
         }
     ],
     "require": {
-        "illuminate/support": "~8.0",
-        "illuminate/database": "~8.0",
-        "illuminate/mail": "~8.0",
-        "illuminate/queue": "~8.0",
+        "illuminate/support": "^8.0|^9.0|^10.0",
+        "illuminate/database": "^8.0|^9.0|^10.0",
+        "illuminate/mail": "^8.0|^9.0|^10.0",
+        "illuminate/queue": "^8.0|^9.0|^10.0",
         "doctrine/dbal": "*"
     },
     "autoload": {


### PR DESCRIPTION
Bumped up Illuminate package versions and also switched to caret version ranges as there are more accommodating with regards to semantic versioning.